### PR TITLE
Update pyproject.toml deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,12 +5,13 @@ authors = ["OpenCRS"]
 version = "0.1.0"
 
 [tool.poetry.dependencies]
-python = "^3.12"
+python = "^3.10"
 pycparser = "^2.21"
 pyelftools = "^0.28"
 docker = "^6.1.2"
 rich = "^12.5.1"
 click = "^8.1.3"
+commons = {path = "../commons"}
 
 [tool.poetry.dev-dependencies]
 black = "^22.6.0"


### PR DESCRIPTION
Using python 3.12 will result into an error
because distutils is no longer supported. Downgrading to python 3.10 will solve this issue.